### PR TITLE
hardknott: fix translation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(name='enigma2-plugin-extensions-youtube',
 		author_email='taapat@gmail.com',
 		package_dir={PLUGIN_DIR: 'src'},
 		packages=[PLUGIN_DIR],
-		package_data={PLUGIN_DIR: ['*.png', 'icons/*.png', '*.svg', 'icons/*.svg']},
+		package_data={PLUGIN_DIR: ['*.png', 'icons/*.png', '*.svg', 'icons/*.svg', 'locale/*/LC_MESSAGES/*.mo']},
 		description='Watch YouTube videos',
 		cmdclass=setup_translate.cmdclass)

--- a/setup_translate.py
+++ b/setup_translate.py
@@ -28,8 +28,7 @@ class build_trans(cmd.Command):
 			if lang.endswith('.po'):
 				src = os.path.join('po', lang)
 				lang = lang[:-3]
-				destdir = os.path.join('build/lib/Extensions/YouTube/locale',
-						lang, 'LC_MESSAGES')
+				destdir = os.path.join('src/locale', lang, 'LC_MESSAGES')
 				if not os.path.exists(destdir):
 					os.makedirs(destdir)
 				dest = os.path.join(destdir, 'YouTube.mo')


### PR DESCRIPTION
Path to build folder doesn't work on hardknott (actually ../build/lib/Extensions/YouTube/locale works, but it sucks).
So better to build locales on plugin and ship it with package_data.