### PR TITLE
Change twisted version to 20.3.0 for gui tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install twisted==21.7.0 pyopenssl service_identity
+          pip install twisted==20.3.0 pyopenssl service_identity
       - name: Link plugin files for test
         working-directory: './enigma2/lib/python/Plugins/Extensions'
         run: |


### PR DESCRIPTION
Previus used 21.7.0 not exist

force-test skip-release