### PR TITLE
Add workaround for python 2.7 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip
@@ -140,7 +140,7 @@ jobs:
           path: './enigma2'
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -207,7 +207,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python 2.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '2.7'
       - name: Install coverage dependencies
@@ -277,7 +277,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python 2.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '2.7'
       - name: Install dependencies

--- a/src/YouTubeUi.py
+++ b/src/YouTubeUi.py
@@ -382,6 +382,7 @@ class YouTubeMain(Screen):
 		self.is_auth = False
 		self.search_result = config.plugins.YouTube.searchResult.value
 		self.thumbnails = {}
+		self.thumbnails['default'] = ''  # Workaround for python 2.7 test
 		self.use_picload = True
 		self.ytapi = None
 		self.yts = [{}]


### PR DESCRIPTION
This fix in python 2.7 tests KeyError: 'default' in thumbnail = self.thumbnails['default'] after thumbnail download error [SSL: KRB5_S_TKT_NYV] unexpected eof while reading (_ssl.c:1946)

Also use setup-python latest v4 tag.

force-test skip-release