### PR TITLE
Use python 3.10 in sonarcloud code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,10 +214,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Python 2.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: '2.7'
+          python-version: '3.10'
       - name: Install coverage dependencies
         run: |
           pip install coverage


### PR DESCRIPTION
Python 2.7 now is deprecated

force-test skip-release