### PR TITLE
Change setup-python actions to MatteoH2O1999 for pyhon 2.7 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: MatteoH2O1999/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade pip
@@ -144,7 +144,7 @@ jobs:
           path: './enigma2'
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: MatteoH2O1999/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -290,7 +290,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python 2.7
-        uses: actions/setup-python@v4
+        uses: MatteoH2O1999/setup-python@v1
         with:
           python-version: '2.7'
       - name: Install dependencies


### PR DESCRIPTION
Python 2.7 support has been removed today.
Therefore, uses the MatteoH2O1999 actions that support deprecated python versions.

force-test skip-release