### PR TITLE
Fix IndexError in YouTubeUi if language in enigma is not set

### DIFF
--- a/src/YouTubeUi.py
+++ b/src/YouTubeUi.py
@@ -54,7 +54,7 @@ config.plugins.YouTube.searchResult = ConfigSelection(default='24',
 		('24', '24'),
 		('50', '50')])
 config.plugins.YouTube.searchRegion = ConfigSelection(
-	default=language.getLanguage().split('_')[1] if language.getLanguage().split('_')[1] != 'EN' else '',
+	default=language.getLanguage().split('_')[1] if language.getLanguage() and language.getLanguage().split('_')[1] != 'EN' else '',
 	choices=[('', _('All'))] + [(x[1], x[0]) for x in ISO3166])
 config.plugins.YouTube.searchLanguage = ConfigSelection(
 	default=language.getLanguage().split('_')[0],

--- a/test/try_plugin.py
+++ b/test/try_plugin.py
@@ -131,6 +131,7 @@ def try_plugin_screens_load():
 		from Components.ServiceEventTracker import ServiceEventTracker
 		func = list(ServiceEventTracker.EventMap.values())[0][0][2]
 		config.plugins.YouTube.lastPosition.value = '["%s", 1]' % session.current_dialog.current[0]
+		config.plugins.YouTube.player.value = '5002'
 		func()
 		session.current_dialog.close(True)
 		session.current_dialog.started = False


### PR DESCRIPTION
When the language in enigma is not set language.getLanguage() returns an empty value which raises an IndexError when trying to parse this value.